### PR TITLE
Set global path variable for project

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ I initially created this project to aid in developing child modules for a WordPr
 + Php
 + Phpmyadmin
 + Subversion
++ Git
++ Composer
 + ~~PEAR~~
 + Xdebug
 + PHPUnit - **installed via composer*
@@ -24,7 +26,7 @@ I initially created this project to aid in developing child modules for a WordPr
 + WordPress sniffs for phpcs
 + WordPress Unit Tests - **installed via composer*
 
-**PEAR removed since as support has reached end of life, see [End of Life for PEAR Installation Method](https://github.com/sebastianbergmann/phpunit/wiki/End-of-Life-for-PEAR-Installation-Method)*
+**PEAR removed as support has reached end of life, see [End of Life for PEAR Installation Method](https://github.com/sebastianbergmann/phpunit/wiki/End-of-Life-for-PEAR-Installation-Method)*
 
 # Prerequisites
 

--- a/puppet/manifests/init.pp
+++ b/puppet/manifests/init.pp
@@ -3,6 +3,10 @@ exec { 'apt_update':
   path    => '/usr/bin'
 }
 
+# set global path variable for project
+# http://www.puppetcookbook.com/posts/set-global-exec-path.html
+Exec { path => [ "/bin/", "/sbin/" , "/usr/bin/", "/usr/sbin/", "/usr/local/bin", "/usr/local/sbin", "~/.composer/vendor/bin/", "/usr/local/bin/vendor/bin/" ] }
+
 class { 'git::install': }
 class { 'subversion::install': }
 class { 'apache2::install': }

--- a/puppet/manifests/init.pp
+++ b/puppet/manifests/init.pp
@@ -5,7 +5,7 @@ exec { 'apt_update':
 
 # set global path variable for project
 # http://www.puppetcookbook.com/posts/set-global-exec-path.html
-Exec { path => [ "/bin/", "/sbin/" , "/usr/bin/", "/usr/sbin/", "/usr/local/bin", "/usr/local/sbin", "~/.composer/vendor/bin/", "/usr/local/bin/vendor/bin/" ] }
+Exec { path => [ "/bin/", "/sbin/" , "/usr/bin/", "/usr/sbin/", "/usr/local/bin", "/usr/local/sbin", "~/.composer/vendor/bin/" ] }
 
 class { 'git::install': }
 class { 'subversion::install': }

--- a/puppet/modules/composer/manifests/init.pp
+++ b/puppet/modules/composer/manifests/init.pp
@@ -8,7 +8,6 @@ class composer::install {
 
   exec { 'install composer':
     command => 'curl -sS https://getcomposer.org/installer | php && sudo mv composer.phar /usr/local/bin/composer',
-    path    => '/usr/bin:/usr/sbin',
     require => Package['curl'],
   }
 

--- a/puppet/modules/mysql/manifests/init.pp
+++ b/puppet/modules/mysql/manifests/init.pp
@@ -18,7 +18,6 @@ class mysql::install {
     ],
     refreshonly => true,
     unless      => "mysqladmin -uroot -p${password} status",
-    path        => '/bin:/usr/bin',
     command     => "mysqladmin -uroot password ${password}",
   }
 

--- a/puppet/modules/phpqa/manifests/init.pp
+++ b/puppet/modules/phpqa/manifests/init.pp
@@ -6,7 +6,6 @@ class phpqa::install{
   exec { "composer install phpunit":
     command => 'composer global require "phpunit/phpunit=4.4.*"',
     environment => ["COMPOSER_HOME=/usr/local/bin"],
-    path    => '/usr/bin:/usr/local/bin:~/.composer/vendor/bin/',
     require => Exec['install composer']
   }
 
@@ -14,7 +13,6 @@ class phpqa::install{
   exec { "composer install phploc":
     command => 'composer global require "phploc/phploc=*"',
     environment => ["COMPOSER_HOME=/usr/local/bin"],
-    path    => '/usr/bin:/usr/local/bin:~/.composer/vendor/bin/',
     require => Exec['install composer']
   }
 
@@ -22,7 +20,6 @@ class phpqa::install{
   exec { "composer install phpcpd":
     command => 'composer global require "sebastian/phpcpd=*"',
     environment => ["COMPOSER_HOME=/usr/local/bin"],
-    path    => '/usr/bin:/usr/local/bin:~/.composer/vendor/bin/',
     require => Exec['install composer']
   }
 
@@ -30,7 +27,6 @@ class phpqa::install{
   exec { "composer install phpcs":
     command => 'composer global require "squizlabs/php_codesniffer=2.1.*"',
     environment => ["COMPOSER_HOME=/usr/local/bin"],
-    path    => '/usr/bin:/usr/local/bin:~/.composer/vendor/bin/',
     require => Exec['install composer']
   }
 
@@ -46,7 +42,6 @@ class phpqa::install{
   exec { "composer install pdepend":
     command => 'composer global require "pdepend/pdepend=2.0.*"',
     environment => ["COMPOSER_HOME=/usr/local/bin"],
-    path    => '/usr/bin:/usr/local/bin:~/.composer/vendor/bin/',
     require => Exec['install composer']
   }
 
@@ -54,7 +49,6 @@ class phpqa::install{
   exec { "composer install phpmd":
     command => 'composer global require "phpmd/phpmd=2.1.*"',
     environment => ["COMPOSER_HOME=/usr/local/bin"],
-    path    => '/usr/bin:/usr/local/bin:~/.composer/vendor/bin/',
     require => Exec['install composer']
   }
 
@@ -62,7 +56,6 @@ class phpqa::install{
   exec { "composer install PHP_CodeBrowser":
     command => 'composer global require "mayflower/php-codebrowser=~1.1"',
     environment => ["COMPOSER_HOME=/usr/local/bin"],
-    path    => '/usr/bin:/usr/local/bin:~/.composer/vendor/bin/',
     require => Exec['install composer']
   }
   


### PR DESCRIPTION
Setting a global path declaration removes the need to specify a path for each Exec command. As a result, all path instances for Exec commands have been removed. As suggested on Puppet CookBook: http://www.puppetcookbook.com/posts/set-global-exec-path.html

Extra path directories can be added to Exec commands when needed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/chad-thompson/vagrantpress/88)
<!-- Reviewable:end -->
