### PR TITLE
add path variable to vagrant user's .bashrc

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,8 @@ Vagrant.configure("2") do |config|
 
   config.vm.network :forwarded_port, guest: 80, host: 8080
 
+  config.vm.provision :shell, path: "files/scripts/setup.sh"
+
   config.vm.provision :puppet do |puppet|
     puppet.manifests_path = "puppet/manifests"
     puppet.module_path = "puppet/modules"

--- a/files/scripts/setup.sh
+++ b/files/scripts/setup.sh
@@ -1,0 +1,6 @@
+# add path variable in vagrant user's .bashrc for installed libraries via composer
+# allows running commands globally in shell for installed composer libraries
+# example: 
+# vagrant@vagrantpress:~$ phpunit --version
+# PHPUnit 4.4.4 by Sebastian Bergmann.
+echo "PATH=$PATH:/usr/local/bin/vendor/bin/" >> /home/vagrant/.bashrc


### PR DESCRIPTION
Added path variable in vagrant user's .bashrc for installed libraries via Composer. Allows running commands globally in shell for installed Composer libraries. Example: 

```shell
vagrant@vagrantpress:~$ phpunit --version
    PHPUnit 4.4.4 by Sebastian Bergmann.
```
Previously, to check a version in the shell for a library installed with Composer, the user had to enter the following in the the shell:

```shell
vagrant@vagrantpress:~$ /usr/local/bin/vendor/bin/phpunit --version
    PHPUnit 4.4.4 by Sebastian Bergmann.
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/chad-thompson/vagrantpress/90)
<!-- Reviewable:end -->
