### PR TITLE
remove forwarded port now that project is using virtual hostname and IP

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,9 +5,6 @@ Vagrant.configure("2") do |config|
   config.vm.box = "trusty64"
   config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
 
-  # set autcorrect flag to prevent port collisions
-  config.vm.network :forwarded_port, guest: 80, host: 8080, auto_correct: true
-
   # allows running commands globally in shell for installed composer libraries
   config.vm.provision :shell, path: "files/scripts/setup.sh"
 


### PR DESCRIPTION
Project now uses virtual hostname and provisioned IP. The forwarded port is no longer needed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/chad-thompson/vagrantpress/94)
<!-- Reviewable:end -->
